### PR TITLE
[F] Include gradle-wrapper.jar in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@
 *.tar.gz
 *.rar
 
+# Include gradle-wrapper.jar
+!/gradle/wrapper/gradle-wrapper.jar
+
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 


### PR DESCRIPTION
Build fails because `gradle-wrapper.jar` is missing from repo.